### PR TITLE
fix sync error

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -31,7 +31,6 @@ services:
   autoDeploy: false
   pullRequestPreviewsEnabled: false
   envVars:
-    - fromGroup: pgbouncer
     - key: DATABASE_URL
       sync: false
     - key: DEFAULT_POOL_SIZE


### PR DESCRIPTION
hmm, even though this is a copy of what is above, i'm getting this error:

services[2].envVars[0].fromGroup
new service cannot link to env group "pgbouncer" which is in environment "Production"

I suppose I need to move the service to our production environment via UI and then add this env group (I don't see how to set this in render.yaml)?