### PR TITLE
splat env group for eu fdw pgbouncer

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -31,7 +31,6 @@ services:
   autoDeploy: false
   pullRequestPreviewsEnabled: false
   envVars:
-    - fromGroup: pgbouncer
     - key: DATABASE_URL
       sync: false
     - key: DEFAULT_POOL_SIZE
@@ -42,6 +41,28 @@ services:
       value: 50
     - key: MIN_POOL_SIZE
       value: 10
+    - key: ADMIN_USERS
+      value: waterhead
+    - key: AUTH_FILE
+      value: /etc/secrets/userlist.txt
+    - key: CLIENT_TLS_CA_FILE
+      value: /etc/secrets/client.ca.crt
+    - key: CLIENT_TLS_CERT_FILE
+      value: /etc/secrets/client.tls.crt
+    - key: CLIENT_TLS_KEY_FILE
+      value: /etc/secrets/client.tls.key
+    - key: CLIENT_TLS_SSLMODE
+      value: require
+    - key: POOL_MODE
+      value: transaction
+    - key: PORT
+      value: 5432
+    - key: SERVER_RESET_QUERY
+      value: DISCARD ALL
+    - key: SERVER_TLS_SSLMODE
+      value: require
+    - key: STATS_USERS
+      value: datadog,opentelemetry_collector
 
 envVarGroups:
   - name: pgbouncer


### PR DESCRIPTION
it's unclear to me in the render docs how the environment variables do or do not override the env groups. I want to be sure that we limit the number of connections, so I'm just going to splat out this entire groups